### PR TITLE
Improve telegram media handler filename generation

### DIFF
--- a/src/handlers/telegram_handler.py
+++ b/src/handlers/telegram_handler.py
@@ -92,13 +92,15 @@ class TelegramHandler:
 
             # 移动文件到目标目录
             ext = os.path.splitext(downloaded_file)[1]
-            target_path = os.path.join(target_dir, f"{filename}{ext}")
-            target_path = target_path.replace(".x-flac", "").replace(".mp4.m4a", ".m4a")
-            if os.path.exists(target_path):
-                filename = f"{filename}_{datetime.now().strftime('%Y%m%d_%H%M%S')}{ext}"
-                target_path = os.path.join(target_dir, filename)
+            if not filename.lower().endswith(ext.lower()):
+                filename = f"{filename}{ext}"
+            filename = filename.replace(".x-flac", "").replace(".mp4.m4a", ".m4a")
+            target_path = os.path.join(target_dir, filename)
 
-            target_path = target_path.replace(ext + ext, ext)
+            while os.path.exists(target_path):
+                base_name, _ = os.path.splitext(filename)
+                filename = f"{base_name}_{datetime.now().strftime('%Y%m%d_%H%M%S%f')}{ext}"
+                target_path = os.path.join(target_dir, filename)
 
             success, result = move_file(downloaded_file, target_path)
 


### PR DESCRIPTION
## Summary
- Ensure Telegram media filenames only include one extension
- Repeatedly generate new filenames until a unique target path is found

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9533df734832fbc4f791d2f9c34ea